### PR TITLE
Adapt caption font size, headline spacing and add an abstract placeholder

### DIFF
--- a/proposal.typ
+++ b/proposal.typ
@@ -38,6 +38,23 @@
   Before you start with your thesis, have a look at our guides on confluence! \ https://confluence.ase.in.tum.de/display/EduResStud/How+to+thesis
 ]
 
+#set heading(numbering: none)
+= Abstract
+// TODO: Remove this block
+#rect(
+  width: 100%,
+  radius: 10%,
+  stroke: 0.5pt,
+  fill: yellow,
+)[
+  *Abstract*
+  
+  - Provide a brief summary of the proposed work 
+  - What is the main content, the main contribution?
+  - What is your methodology? How do you proceed?
+]
+
+#set heading(numbering: "1.1")
 = Introduction
 
 // TODO: Remove this block

--- a/proposal_template.typ
+++ b/proposal_template.typ
@@ -32,15 +32,18 @@
     lang: "en"
   )
 
-  // Set heading settings
-  set heading(numbering: "1.1")
-  
   show math.equation: set text(weight: 400)
 
-  show figure: set text(size: 0.85em)
+  // --- Headings ---
+  show heading: set block(below: 0.85em, above: 1em)
+  show heading: set text(font: body-font)
+  set heading(numbering: "1.1")
 
-  // Main body.
+  // --- Paragraphs ---
   set par(leading: 1em, justify: true)
+
+  // --- Figures ---
+  show figure: set text(size: 0.85em)
 
   body
 

--- a/proposal_template.typ
+++ b/proposal_template.typ
@@ -31,13 +31,16 @@
     size: 12pt, 
     lang: "en"
   )
-  show math.equation: set text(weight: 400)
-  show heading: set text(font: body-font)
+
+  // Set heading settings
   set heading(numbering: "1.1")
-  set par(leading: 1em)
+  
+  show math.equation: set text(weight: 400)
+
+  show figure: set text(size: 0.85em)
 
   // Main body.
-  set par(justify: true)
+  set par(leading: 1em, justify: true)
 
   body
 

--- a/proposal_template.typ
+++ b/proposal_template.typ
@@ -35,7 +35,7 @@
   show math.equation: set text(weight: 400)
 
   // --- Headings ---
-  show heading: set block(below: 0.85em, above: 1.25em)
+  show heading: set block(below: 0.85em, above: 1.75em)
   show heading: set text(font: body-font)
   set heading(numbering: "1.1")
 

--- a/proposal_template.typ
+++ b/proposal_template.typ
@@ -35,7 +35,7 @@
   show math.equation: set text(weight: 400)
 
   // --- Headings ---
-  show heading: set block(below: 0.85em, above: 1em)
+  show heading: set block(below: 0.85em, above: 1.25em)
   show heading: set text(font: body-font)
   set heading(numbering: "1.1")
 

--- a/thesis_template.typ
+++ b/thesis_template.typ
@@ -25,13 +25,19 @@
     size: 12pt, 
     lang: "en"
   )
+  
   show math.equation: set text(weight: 400)
+
+  // --- Headings ---
+  show heading: set block(below: 0.85em, above: 1em)
   show heading: set text(font: body-font)
   set heading(numbering: "1.1")
+
+  // --- Paragraphs ---
   set par(leading: 1em)
 
-  
-
+  // --- Figures ---
+  show figure: set text(size: 0.85em)
   
   // --- Table of Contents ---
   outline(

--- a/thesis_template.typ
+++ b/thesis_template.typ
@@ -29,7 +29,7 @@
   show math.equation: set text(weight: 400)
 
   // --- Headings ---
-  show heading: set block(below: 0.85em, above: 1em)
+  show heading: set block(below: 0.85em, above: 1.75em)
   show heading: set text(font: body-font)
   set heading(numbering: "1.1")
 


### PR DESCRIPTION
This pull request adapts the font size in figure captions to be equal to the font size used on foot notes, adds more spacing below headlines and adds a placeholder section for an abstract to the proposal template.

The updated spacing:
<img width="476" alt="Screenshot 2023-09-14 at 09 32 46" src="https://github.com/ls1intum/thesis-template-typst/assets/143808484/8f0500a6-587e-49af-a3e8-90f01a515fc7">


The abstract placeholder:
<img width="474" alt="Screenshot 2023-09-13 at 17 03 06" src="https://github.com/ls1intum/thesis-template-typst/assets/143808484/82956557-bb3f-4f9a-ab50-0a2ddf3507ab">
