### PR TITLE
Reference first-level headings as "chapters" instead of "sections"

### DIFF
--- a/thesis_template.typ
+++ b/thesis_template.typ
@@ -28,6 +28,20 @@
   show math.equation: set text(weight: 400)
   show heading: set text(font: body-font)
   set heading(numbering: "1.1")
+  // Reference first-level headings as "chapters"
+  show ref: it => {
+    let el = it.element
+    if el != none and el.func() == heading and el.level == 1 {
+      [Chapter ]
+      numbering(
+        el.numbering,
+        ..counter(heading).at(el.location())
+      )
+    } else {
+      it
+    }
+  }
+
   set par(leading: 1em)
 
   


### PR DESCRIPTION
In the Latex template, we call top-level sections "chapters". This PR also changes the names of referenced top-level sections to "chapter".

Before:
![screenshot-2023-09-14_001970](https://github.com/ls1intum/thesis-template-typst/assets/9006596/fdf2a1cc-75a6-4006-b441-8c1f919d863c)

After:
![screenshot-2023-09-14_001969](https://github.com/ls1intum/thesis-template-typst/assets/9006596/66311ed7-30b2-40e9-8b81-7f0c015c483a)
