### PR TITLE
Change citation style to alphanumerical

### DIFF
--- a/thesis_template.typ
+++ b/thesis_template.typ
@@ -36,6 +36,9 @@
   // --- Paragraphs ---
   set par(leading: 1em)
 
+  // --- Citations ---
+  set cite(style: "alphanumerical")
+
   // --- Figures ---
   show figure: set text(size: 0.85em)
   


### PR DESCRIPTION
In the Latex template, the citation style is alphanumerical. This template currently uses plain numbers as references. This PR changes that.

Before:
![screenshot-2023-09-14_001971](https://github.com/ls1intum/thesis-template-typst/assets/9006596/ad98c671-eea1-4203-b43a-753132218a3b)

After:
![screenshot-2023-09-14_001972](https://github.com/ls1intum/thesis-template-typst/assets/9006596/16ccdbb0-04ff-46c9-9ade-dc2b7a9ef892)
