### PR TITLE
Fix citation type (alphanumerical -> alphanumeric)

### DIFF
--- a/thesis_template.typ
+++ b/thesis_template.typ
@@ -50,7 +50,7 @@
   set par(leading: 1em)
 
   // --- Citations ---
-  set cite(style: "alphanumerical")
+  set cite(style: "alphanumeric")
 
   // --- Figures ---
   show figure: set text(size: 0.85em)


### PR DESCRIPTION
### Description
This PR fixes the citation type parameter. The one used originally is `alphanumerical`, the right one is `alphanumeric`. 

Based on: https://typst.app/docs/reference/meta/bibliography/#parameters-style

This line was recently added in #9 . Most likely a version update caused it to fail now.

### How to test?
Download the template and verify that typst.app compiles the document correctly.