### PR TITLE
Justify abstract text

### DIFF
--- a/thesis_typ/abstract_de.typ
+++ b/thesis_typ/abstract_de.typ
@@ -14,19 +14,19 @@
     lang: "en"
   )
   
-  set par(leading: 1em)
+  set par(
+    leading: 1em,
+    justify: true
+  )
 
   
   // --- Abstract (EN) ---
   v(1fr)
   align(center, text(font: body-font, 1em, weight: "semibold", "Zusammenfassung"))
   
-  align(
-    center, 
-    text[
-      Note: Insert the German translation of the English abstract here.
-    ]
-  )
+  text[
+    Note: Insert the German translation of the English abstract here.
+  ]
   
   v(1fr)
 }

--- a/thesis_typ/abstract_en.typ
+++ b/thesis_typ/abstract_en.typ
@@ -14,7 +14,10 @@
     lang: "en"
   )
 
-  set par(leading: 1em)
+  set par(
+    leading: 1em,
+    justify: true
+  )
 
   
   // --- Abstract (DE) ---


### PR DESCRIPTION
Content of the abstract was aligned to the left instead of being justified. This PR fixes that issue.