### PR TITLE
'Bugfix': Add missing first-line-indent to proposal_template.typ

### DIFF
--- a/proposal_template.typ
+++ b/proposal_template.typ
@@ -40,7 +40,7 @@
   set heading(numbering: "1.1")
 
   // --- Paragraphs ---
-  set par(leading: 1em, justify: true)
+  set par(leading: 1em, justify: true, first-line-indent: 2em)
 
   // --- Figures ---
   show figure: set text(size: 0.85em)


### PR DESCRIPTION
This bugfix adds a missing first-line-indent for new paragraphs in the proposal template