### PR TITLE
`Bugfix`: Add missing first-line-indent to thesis_template.typ

### DIFF
--- a/thesis_template.typ
+++ b/thesis_template.typ
@@ -70,7 +70,7 @@
 
 
   // Main body.
-  set par(justify: true)
+  set par(justify: true, first-line-indent: 2em)
 
   body
 


### PR DESCRIPTION
This bugfix adds a missing first-line-indent for new paragraphs in the thesis template