### PR TITLE
Perform set before content

### DIFF
--- a/common/cover.typ
+++ b/common/cover.typ
@@ -4,7 +4,6 @@
   program: "",
   author: "",
 ) = {
-  set document(title: title, author: author)
   set page(
     margin: (left: 30mm, right: 30mm, top: 40mm, bottom: 40mm),
     numbering: none,

--- a/common/titlepage.typ
+++ b/common/titlepage.typ
@@ -9,7 +9,6 @@
   startDate: none,
   submissionDate: none,
 ) = {
-  set document(title: title, author: author)
   set page(
     margin: (left: 30mm, right: 30mm, top: 40mm, bottom: 40mm),
     numbering: none,

--- a/proposal.typ
+++ b/proposal.typ
@@ -2,6 +2,7 @@
 #import "common/titlepage.typ": *
 #import "common/metadata.typ": *
 
+#set document(title: titleEnglish, author: author)
 
 #titlepage(
   title: titleEnglish,

--- a/proposal_template.typ
+++ b/proposal_template.typ
@@ -14,7 +14,6 @@
   body,
 ) = {
   // Set the document's basic properties.
-  set document(title: title, author: author)
   set page(
     margin: (left: 30mm, right: 30mm, top: 40mm, bottom: 40mm),
     numbering: "1",

--- a/thesis.typ
+++ b/thesis.typ
@@ -8,6 +8,8 @@
 #import "common/metadata.typ": *
 
 
+#set document(title: titleEnglish, author: author)
+
 #cover(
   title: titleEnglish,
   degree: degree,

--- a/thesis_template.typ
+++ b/thesis_template.typ
@@ -10,7 +10,6 @@
   submissionDate: none,
   body,
 ) = {
-  set document(title: title, author: author)
   set page(
     margin: (left: 30mm, right: 30mm, top: 40mm, bottom: 40mm),
     numbering: "1",

--- a/thesis_typ/disclaimer.typ
+++ b/thesis_typ/disclaimer.typ
@@ -4,7 +4,6 @@
   author: "",
   submissionDate: none,
 ) = {
-  set document(title: title, author: author)  
   set page(
     margin: (left: 30mm, right: 30mm, top: 40mm, bottom: 40mm),
     numbering: none,


### PR DESCRIPTION
This PR mitigates a compile error and sets `document` once in the top-level documents, proposal and thesis, respectively.

---

Typst 0.11.0 contains a breaking change:

> Setting properties on an element within a transformational show rule (e.g. show heading: it => { set heading(..); it }) is not supported anymore (previously it also only worked sometimes); use show-set rules instead (Breaking change)

Ref.: https://github.com/typst/typst/releases/tag/v0.11.0