### PR TITLE
Add indent of first paragraph after a headline

### DIFF
--- a/proposal_template.typ
+++ b/proposal_template.typ
@@ -39,6 +39,11 @@
   set heading(numbering: "1.1")
 
   // --- Paragraphs ---
+  let firstParagraphIndent = 1.45em
+  show heading: it => {
+    it
+    h(firstParagraphIndent)
+  }
   set par(leading: 1em, justify: true, first-line-indent: 2em)
 
   // --- Figures ---


### PR DESCRIPTION
Due to the typst bug [311](https://github.com/typst/typst/issues/311) the first paragraph is not indented. With the introduced the indention problem after headlines is solved.