### PR TITLE
Add feedback log for presentations

### DIFF
--- a/feedbacklog.typ
+++ b/feedbacklog.typ
@@ -1,0 +1,24 @@
+#import "/layout/feedbacklog_template.typ": *
+#import "/metadata.typ": *
+#import "/utils/feedback.typ": *
+
+#set document(title: titleEnglish, author: author)
+
+#show: feedbacklog.with(
+  titleEnglish: titleEnglish,
+  supervisor: supervisor,
+  advisors: advisors,
+  author: author,
+  presentationDate: presentationDate,
+  feedbacklogSubmissionDate: feedbacklogSubmissionDate,
+)
+
+#feedback(
+  feedback: "Since the attention span of the audience is rather short, try getting to the problem as fast as possible. Several slides in the presentation display redundant or repetitive information and could be deleted",
+  response: "To  get  to  the  problem  earlier  in  the  presentation  as  well  as  to  present  only relevant  information,  some  of  the  slides  are  removed  (Agenda)  and  some  of  them  are  merged (Context, Motivation and Objectives), therefore the “Problem” slide is now at slide 4."
+)
+
+#feedback(
+  feedback: "The structure of the presentation is rather unique; it would be great if you could help the audience to follow it easier.",
+  response: "To help the audience to follow the presentation easier, a progress-bar was added at the bottom of the slides to show the milestones of the presentation and highlight the one that indicates the current slide."
+)

--- a/layout/feedbacklog_template.typ
+++ b/layout/feedbacklog_template.typ
@@ -1,0 +1,58 @@
+#let feedbacklog(
+  titleEnglish: "",
+  supervisor: "",
+  advisors: (),
+  author: "",
+  presentationDate: datetime,
+  feedbacklogSubmissionDate: datetime,
+  body,
+) = {
+  // Set the document's basic properties.
+  set page(
+    margin: (left: 30mm, right: 30mm, top: 40mm, bottom: 40mm),
+    numbering: "1",
+    number-align: center,
+  )
+
+  // Save heading and body font families in variables.
+  let body-font = "New Computer Modern"
+  let sans-font = "New Computer Modern Sans"
+
+  // Set body font family.
+  set text(
+    font: body-font, 
+    size: 12pt, 
+    lang: "en"
+  )
+  
+  align(center, text(font: "sans-font", 1.7em, weight: 700, "Presentation Feedbacklog" + linebreak() + titleEnglish))
+
+  v(7.5mm)
+
+  align(center, text(font: "sans-font", 1.2em, weight: 400, feedbacklogSubmissionDate.display("[day]. [month repr:long] [year]")))
+
+  v(7.5mm)
+
+  line(length: 100%, stroke: 0.5pt)
+
+  align(
+    center,
+    box(
+      align(
+        left,
+        grid(
+          columns: 2,
+          gutter: 1em,
+          strong("Author: "), author,
+          strong("Supervisor: "), supervisor,
+          strong("Advisors: "), advisors.join(",\n"),
+          strong("Presentation Date: "), presentationDate.display("[day].[month].[year]"),
+        )
+      )
+    )
+  )
+
+  line(length: 100%, stroke: 0.5pt)
+
+  body
+}

--- a/metadata.typ
+++ b/metadata.typ
@@ -8,3 +8,5 @@
 #let author = "(Author)"
 #let startDate = datetime(day: 1, month: 1, year: 2024)
 #let submissionDate = datetime(day: 1, month: 1, year: 2024)
+#let presentationDate = datetime(day: 1, month: 1, year: 2024)
+#let feedbacklogSubmissionDate = datetime(day: 1, month: 1, year: 2024)

--- a/utils/feedback.typ
+++ b/utils/feedback.typ
@@ -1,0 +1,25 @@
+#let feedback(
+    feedback: "",
+    response: "",
+) = {
+    counter("feedback").step()
+    block(
+        breakable: false,
+        (
+            par(
+                justify: true,            
+                text(weight: 700, counter("feedback").display() + ". Feedback: ") +
+                feedback + 
+                pad(
+                    left: 5%,
+                    top: 2mm,
+                    bottom: 5mm,
+                    text(
+                        fill: blue,
+                        text(weight: 700, "Response: ") + response
+                    )
+                )
+            ) 
+        )
+    )
+}


### PR DESCRIPTION
Converting the [presentation feedback log](https://github.com/ls1intum/presentation-feedback-log-template) from LaTeX to Typst.

[feedbacklog.pdf](https://github.com/user-attachments/files/16218873/feedbacklog.pdf)
