### PR TITLE
Enhance Table of Contents styling for level 1 entries

### DIFF
--- a/layout/thesis_template.typ
+++ b/layout/thesis_template.typ
@@ -110,6 +110,10 @@
   show figure: set text(size: 0.85em)
   
   // --- Table of Contents ---
+  show outline.entry.where(level: 1): it => {
+    v(15pt, weak: true)
+    strong(it)
+  }
   outline(
     title: {
       text(font: body-font, 1.5em, weight: 700, "Contents")


### PR DESCRIPTION
This pull request includes a change to the `layout/thesis_template.typ` file to improve the formatting of the Table of Contents. The most important change is the addition of a new rule to display level 1 entries in the Table of Contents with a specific format.