### PR TITLE
Reset page numbering after outline

### DIFF
--- a/layout/thesis_template.typ
+++ b/layout/thesis_template.typ
@@ -65,7 +65,7 @@
 
   set page(
     margin: (left: 30mm, right: 30mm, top: 40mm, bottom: 40mm),
-    numbering: "1",
+    numbering: none,
     number-align: center,
   )
 
@@ -123,7 +123,9 @@
   pagebreak()
 
 
-  // Main body.
+    // Main body. Reset page numbering.
+  set page(numbering: "1")
+  counter(page).update(1)
   set par(justify: true, first-line-indent: 2em)
 
   body


### PR DESCRIPTION
This pull request includes changes to the `layout/thesis_template.typ` file to modify the page numbering format and reset the page numbering for the main body. 