### PR TITLE
chore: add fonts to github actions

### DIFF
--- a/.github/workflows/build-release-thesis.yml
+++ b/.github/workflows/build-release-thesis.yml
@@ -36,6 +36,7 @@ jobs:
       - run: typst compile thesis.typ thesis.pdf
       - run: typst compile proposal.typ proposal.pdf
       - run: typst compile registration_certificate.typ registration_certificate.pdf
+      - run: typst compile feedbacklog.typ feedbacklog.pdf
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/build-release-thesis.yml
+++ b/.github/workflows/build-release-thesis.yml
@@ -18,6 +18,14 @@ jobs:
           fetch-depth: '0'
           lfs: true
 
+      - name: Download and Install New Computer Modern Font
+        run: |
+            mkdir -p ~/.local/share/fonts
+            wget -O /tmp/newcomputermodern.zip "https://fontesk.com/download/39191"
+            unzip /tmp/newcomputermodern.zip -d /tmp/
+            cp -r /tmp/*.otf ~/.local/share/fonts/
+            fc-cache -f -v  # Refresh font cache
+
       - name: Create initial tag
         run: |
           if [ -z "$(git tag -l 'v*')" ]; then
@@ -31,14 +39,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: 'patch'
-
-      - name: Download and Install New Computer Modern Font
-        run: |
-              mkdir -p ~/.local/share/fonts
-              wget -O /tmp/newcomputermodern.zip "https://fontesk.com/download/39191"
-              unzip /tmp/newcomputermodern.zip -d /tmp/
-              cp -r /tmp/*.otf ~/.local/share/fonts/
-              fc-cache -f -v  # Refresh font cache
 
       - uses: typst-community/setup-typst@v4
       - run: typst compile thesis.typ thesis.pdf

--- a/.github/workflows/build-release-thesis.yml
+++ b/.github/workflows/build-release-thesis.yml
@@ -32,6 +32,14 @@ jobs:
           WITH_V: true
           DEFAULT_BUMP: 'patch'
 
+      - name: Download and Install New Computer Modern Font
+        run: |
+              mkdir -p ~/.local/share/fonts
+              wget -O /tmp/newcomputermodern.zip "https://fontesk.com/download/39191"
+              unzip /tmp/newcomputermodern.zip -d /tmp/
+              cp -r /tmp/*.otf ~/.local/share/fonts/
+              fc-cache -f -v  # Refresh font cache
+
       - uses: typst-community/setup-typst@v4
       - run: typst compile thesis.typ thesis.pdf
       - run: typst compile proposal.typ proposal.pdf

--- a/.github/workflows/build-release-thesis.yml
+++ b/.github/workflows/build-release-thesis.yml
@@ -32,7 +32,7 @@ jobs:
           WITH_V: true
           DEFAULT_BUMP: 'patch'
 
-      - uses: typst-community/setup-typst@v3
+      - uses: typst-community/setup-typst@v4
       - run: typst compile thesis.typ thesis.pdf
       - run: typst compile proposal.typ proposal.pdf
       - run: typst compile registration_certificate.typ registration_certificate.pdf

--- a/.github/workflows/build-release-thesis.yml
+++ b/.github/workflows/build-release-thesis.yml
@@ -36,9 +36,6 @@ jobs:
           cp -r /tmp/*.otf ~/.local/share/fonts/
           fc-cache -f -v  # Refresh font cache
 
-      - name: Verify Font Installation
-        run: fc-list | grep "New Computer Modern"
-
       - name: Create initial tag
         run: |
           if [ -z "$(git tag -l 'v*')" ]; then

--- a/.github/workflows/build-release-thesis.yml
+++ b/.github/workflows/build-release-thesis.yml
@@ -18,13 +18,26 @@ jobs:
           fetch-depth: '0'
           lfs: true
 
-      - name: Download and Install New Computer Modern Font
+      - name: Cache Fonts
+        id: cache-fonts
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/fonts
+          key: newcomputermodern-fonts-${{ runner.os }}
+          restore-keys: |
+            newcomputermodern-fonts-
+
+      - name: Install Fonts (if not cached)
+        if: steps.cache-fonts.outputs.cache-hit != 'true'
         run: |
-            mkdir -p ~/.local/share/fonts
-            wget -O /tmp/newcomputermodern.zip "https://fontesk.com/download/39191"
-            unzip /tmp/newcomputermodern.zip -d /tmp/
-            cp -r /tmp/*.otf ~/.local/share/fonts/
-            fc-cache -f -v  # Refresh font cache
+          mkdir -p ~/.local/share/fonts
+          wget -O /tmp/newcomputermodern.zip "https://fontesk.com/download/39191"
+          unzip /tmp/newcomputermodern.zip -d /tmp/
+          cp -r /tmp/*.otf ~/.local/share/fonts/
+          fc-cache -f -v  # Refresh font cache
+
+      - name: Verify Font Installation
+        run: fc-list | grep "New Computer Modern"
 
       - name: Create initial tag
         run: |

--- a/.github/workflows/build-typst.yml
+++ b/.github/workflows/build-typst.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: '0'
           lfs: true
 
-      - uses: typst-community/setup-typst@v3
+      - uses: typst-community/setup-typst@v4
       - run: typst compile thesis.typ thesis.pdf
       - run: typst compile proposal.typ proposal.pdf
       - run: typst compile registration_certificate.typ registration_certificate.pdf

--- a/.github/workflows/build-typst.yml
+++ b/.github/workflows/build-typst.yml
@@ -14,6 +14,24 @@ jobs:
           fetch-depth: '0'
           lfs: true
 
+      - name: Cache Fonts
+        id: cache-fonts
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/fonts
+          key: newcomputermodern-fonts-${{ runner.os }}
+          restore-keys: |
+            newcomputermodern-fonts-
+
+      - name: Install Fonts (if not cached)
+        if: steps.cache-fonts.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.local/share/fonts
+          wget -O /tmp/newcomputermodern.zip "https://fontesk.com/download/39191"
+          unzip /tmp/newcomputermodern.zip -d /tmp/
+          cp -r /tmp/*.otf ~/.local/share/fonts/
+          fc-cache -f -v  # Refresh font cache
+
       - uses: typst-community/setup-typst@v4
       - run: typst compile thesis.typ thesis.pdf
       - run: typst compile proposal.typ proposal.pdf

--- a/.github/workflows/build-typst.yml
+++ b/.github/workflows/build-typst.yml
@@ -18,3 +18,4 @@ jobs:
       - run: typst compile thesis.typ thesis.pdf
       - run: typst compile proposal.typ proposal.pdf
       - run: typst compile registration_certificate.typ registration_certificate.pdf
+      - run: typst compile feedbacklog.typ feedbacklog.pdf


### PR DESCRIPTION
Hi,
just a quick add to Github Actions to add the fonts which are used in the automatic creation of the *.pdf files.

Using https://fontesk.com/new-computer-modern-typeface/ for downloading of the fonts.

Before:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/9a9168fc-a111-4b86-8ebc-6d59f80a332c" />

After:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/29bb6a36-5fcc-4182-bfad-9fca42af694a" />



Best regards
Marvin Simon