### PR TITLE
Convert thesis.bib file to yml

### DIFF
--- a/layout/proposal_template.typ
+++ b/layout/proposal_template.typ
@@ -72,7 +72,7 @@
   body
 
   pagebreak()
-  bibliography("/thesis.bib")
+  bibliography("/thesis.yml")
   pagebreak()
   transparency_ai_tools_layout(transparency_ai_tools)
 }

--- a/layout/thesis_template.typ
+++ b/layout/thesis_template.typ
@@ -164,5 +164,5 @@
   include("/layout/appendix.typ")
 
   pagebreak()
-  bibliography("/thesis.bib")
+  bibliography("/thesis.yml")
 }

--- a/thesis.bib
+++ b/thesis.bib
@@ -1,6 +1,0 @@
-@book{bruegge2004object,
-	title = {Object Oriented Software Engineering Using UML, Patterns, and Java},
-	author = {Bruegge, Bernd and Dutoit, Allen H},
-	year = {2009},
-	publisher = {Prentice Hall}
-}

--- a/thesis.yml
+++ b/thesis.yml
@@ -1,0 +1,8 @@
+bruegge2004object:
+  type: book
+  title: Object Oriented Software Engineering Using UML, Patterns, and Java
+  author:
+    - Bruegge, Bernd
+    - Dutoit, Allen H
+  date: 2009
+  publisher: Prentice Hall


### PR DESCRIPTION
This PR updates the thesis template to use Typst’s native .yml (Hayagriva) format instead of BibTeX .bib files.

Why the change?
	•	Typst’s .bib support is limited (e.g., missing school, type, booktitle)
	•	.yml allows full rendering of thesis types and conference entries
	•	Cleaner, more flexible, and fully compatible with Typst’s citation engine