### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-typst.yml
+++ b/.github/workflows/build-typst.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build typst
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ls1intum/thesis-template-typst/security/code-scanning/1](https://github.com/ls1intum/thesis-template-typst/security/code-scanning/1)

To fix the issue, a `permissions` block should be added to the root of the workflow, which will apply to all jobs unless overridden by specific job-level permissions. Since this workflow primarily accesses repository contents for compiling and caching files, the minimal required permission is `contents: read`.

**Steps**:
1. Add a `permissions` block at the root level of the workflow.
2. Set `contents: read` to limit access to read-only operations on repository content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
