### PR TITLE
Render "supervisor" singular if there is only one

### DIFF
--- a/layout/feedbacklog_template.typ
+++ b/layout/feedbacklog_template.typ
@@ -38,7 +38,8 @@
   entries.push(("Examiner: ", examiner))
   // Only show supervisors if there are any
   if supervisors.len() > 0 {
-    entries.push(("Supervisors: ", supervisors.join(", ")))
+    let supervisorField = "Supervisor" + if supervisors.len() > 1 [s] + ": "
+    entries.push((supervisorField, supervisors.join(", ")))
   }
   entries.push(("Presentation Date: ", presentationDate.display("[day].[month].[year]")))
 

--- a/layout/titlepage.typ
+++ b/layout/titlepage.typ
@@ -55,7 +55,8 @@
   entries.push(("Examiner: ", examiner))
   // Only show supervisors if there are any
   if supervisors.len() > 0 {
-    entries.push(("Supervisors: ", supervisors.join(", ")))
+    let supervisorField = "Supervisor" + if supervisors.len() > 1 [s] + ": "
+    entries.push((supervisorField, supervisors.join(", ")))
   }
   entries.push(("Start Date: ", startDate.display("[day].[month].[year]")))
   entries.push(("Submission Date: ", submissionDate.display("[day].[month].[year]")))


### PR DESCRIPTION
This PR changes the title page rendering logic such that the "Supervisor" field is displayed in singular form if there is only a single element in the corresponding metadata field.